### PR TITLE
Avoid converting Iterator to List and use gzip

### DIFF
--- a/src/main/scala/com/gu/zuora/fullexport/Cli.scala
+++ b/src/main/scala/com/gu/zuora/fullexport/Cli.scala
@@ -22,7 +22,7 @@ object Cli extends App with LazyLogging {
   private def startExportProcess(in: Input): Unit = {
     implicit val nonDeamonEc = ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
     val overallResultF = Future.traverse(in.objects) { obj =>
-      Future(retry(1)(exportObject(obj, in.beginningOfTime)))
+      Future(retry(2)(exportObject(obj, in.beginningOfTime)))
         .andThen(logRunningStatus(obj))
     }
     logFinalResultWithDelay(overallResultF, in)


### PR DESCRIPTION
### Load `Iterator[String]` instead of `String`

[Avoid](https://github.com/pathikrit/better-files#streams) `toList` calls which load contents into memory. Heap would peek above 4GB raising `java.lang.OutOfMemoryError: Java heap space` on later monthly `InvoiceItem` chunks which are around 500 MBs and 800K records.

[Daniel Spiewak](https://stackoverflow.com/a/1286147/5205022) states

> I would be wary of reading an entire file into a single `String`. It's a very bad habit, one which will bite you sooner and harder than you think. The getLines method returns a value of type `Iterator[String]`. It's effectively a lazy cursor into the file, allowing you to examine just the data you need without risking memory glut.

### Download `gzip` instead of `csv`
Also improve download times by making Zuora AQuA provide gzip compressed result files