### PR TITLE
extract CorporateAccountId__c and RedemptionCode__c from subs table

### DIFF
--- a/input.json
+++ b/input.json
@@ -182,7 +182,9 @@
         "IsInvoiceSeparate",
         "LastPriceChangeDate__c",
         "legacy_cat__c",
-        "LegacyContractStartDate__c"
+        "LegacyContractStartDate__c",
+        "CorporateAccountId__c",
+        "RedemptionCode__c"
       ]
     },
     {


### PR DESCRIPTION
This PR is related to https://github.com/guardian/support-service-lambdas/pull/671

https://trello.com/c/GfucWmsP/3068-get-redemption-code-corporate-code-into-dl-for-the-redemption-reporting-subs-table

We have to extract the full data from Zuora before we can carry on the incremental load with the new fields.

This PR adds the same fields in the same order as the above PR so that the full load will be compatible with the incremental job going forward.