### PR TITLE
build: update Scala and sbt versions to make Scala Steward pass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion     := "2.13.8"
+ThisBuild / scalaVersion     := "2.13.11"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.gu"
 ThisBuild / organizationName := "The Guardian"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.9.0


### PR DESCRIPTION
## What does this change?

[Issue](https://github.com/guardian/zuora-full-export/issues)

- Update Scala version to 2.13.11
- Update sbt version to 1.9.0

This is required to make the [Scala Steward build](https://github.com/guardian/maintaining-scala-projects/issues/7) to pass.

Thanks @rtyley for flagging.