### PR TITLE
 Submit sbt dependencies to GitHub for vulnerability monitoring

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - sbt-dependency-graph-zuora-full-export
   workflow_dispatch: 
 jobs:
   dependency-graph:

--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -1,0 +1,31 @@
+name: Update Dependency Graph for sbt
+on:
+  push:
+    branches:
+      - main
+      - sbt-dependency-graph-zuora-full-export
+  workflow_dispatch: 
+jobs:
+  dependency-graph:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        id: checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Install Java
+        id: java
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
+        with:
+          distribution: corretto
+          java-version: 17
+      - name: Install sbt
+        id: sbt
+        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+      - name: Submit dependencies
+        id: submit
+        uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
+      - name: Log snapshot for user validation
+        id: validate
+        run: cat ${{ steps.submit.outputs.snapshot-json-path }} | jq
+    permissions:
+      contents: write


### PR DESCRIPTION
## What does this change?

NOTE: this workflow will fail after merge as it runs on the `main` branch. We suggest changing the default branch from `master` to `main` rather than amending the workflow, as this follows [our recommendations](https://github.com/guardian/recommendations/blob/bcb8a97a70c5604da558cc5c4b1e3cb48f4ebe9e/github.md#default-branch-name).

This PR sends your sbt dependencies to GitHub for vulnerability monitoring via Dependabot. The submitted dependencies will appear in the [Dependency Graph](https://github.com/guardian/mobile-notifications-content/network/dependencies) on merge to main (it might take a few minutes to update).

## What do I need to do?
- [x] Change the default branch from `master` to `main`.
- [x] Ensure that the [version of sbt in the project is v1.5 or above](https://github.com/scalacenter/sbt-dependency-submission?tab=readme-ov-file#support) in order for the dependency submission action to run.
- [x] A run of this action (Update Dependency Graph for sbt) should have been triggered (see the checks below) when the branch `sbt-dependency-graph-12d01aaba799fac2` was created. Sense check the output of the step "Log snapshot for user validation", and make sure that your dependencies look okay.
- [x] When you are happy the action works, remove the branch name trigger `sbt-dependency-graph-12d01aaba799fac2` from the file `sbt-dependency-graph.yaml` (aka delete line 6), approve this PR, and merge. 
## Why?

If a repository is in production, we need to track its third party dependencies for vulnerabilities. Historically, we have done this using Snyk, but we are now moving to GitHub’s native Dependabot. Scala is not a language that Dependabot supports out of the box, this workflow is required to make it happen. As a result, we have raised this PR on your behalf to add it to the Dependency Graph.

## How has it been verified?

We have tested this workflow, and the process of raising a PR on DevX repos, and have verified that it works. However, we have included some instructions above to help you verify that it works for you. Please do not hesitate to contact DevX Security if you have any questions or concerns.

## Further information for sbt

See [the sbt workflow documentation](https://github.com/scalacenter/sbt-dependency-submission?tab=readme-ov-file) for further information and configuration options.