### PR TITLE
Update README.md to remove ACL setting from s3 upload instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,19 +73,19 @@ This step is currently not automated. Import fresh janus credentials and execute
 upload commands have to include `--acl`: 
 
 ```scala
-aws s3 cp  Account.csv              s3://ophan-raw-zuora-increment-account/            --acl bucket-owner-read --profile membership
-aws s3 cp  RatePlanCharge.csv       s3://ophan-raw-zuora-increment-rateplancharge/     --acl bucket-owner-read --profile membership
-aws s3 cp  RatePlanChargeTier.csv   s3://ophan-raw-zuora-increment-rateplanchargetier/ --acl bucket-owner-read --profile membership
-aws s3 cp  RatePlan.csv             s3://ophan-raw-zuora-increment-rateplan/           --acl bucket-owner-read --profile membership
-aws s3 cp  Subscription.csv         s3://ophan-raw-zuora-increment-subscription/       --acl bucket-owner-read --profile membership
-aws s3 cp  Contact.csv              s3://ophan-raw-zuora-increment-contact/            --acl bucket-owner-read --profile membership
-aws s3 cp  PaymentMethod.csv        s3://ophan-raw-zuora-increment-paymentmethod/      --acl bucket-owner-read --profile membership
-aws s3 cp  Amendment.csv            s3://ophan-raw-zuora-increment-amendment/          --acl bucket-owner-read --profile membership
-aws s3 cp  Invoice.csv              s3://ophan-raw-zuora-increment-invoice/            --acl bucket-owner-read --profile membership
-aws s3 cp  Payment.csv              s3://ophan-raw-zuora-increment-payment/            --acl bucket-owner-read --profile membership
-aws s3 cp  InvoicePayment.csv       s3://ophan-raw-zuora-increment-invoicepayment/     --acl bucket-owner-read --profile membership
-aws s3 cp  Refund.csv               s3://ophan-raw-zuora-increment-refund/             --acl bucket-owner-read --profile membership
-aws s3 cp  InvoiceItem.csv          s3://ophan-raw-zuora-increment-invoiceitem/        --acl bucket-owner-read --profile membership
+aws s3 cp  Account.csv              s3://ophan-raw-zuora-increment-account/            --profile membership
+aws s3 cp  RatePlanCharge.csv       s3://ophan-raw-zuora-increment-rateplancharge/     --profile membership
+aws s3 cp  RatePlanChargeTier.csv   s3://ophan-raw-zuora-increment-rateplanchargetier/ --profile membership
+aws s3 cp  RatePlan.csv             s3://ophan-raw-zuora-increment-rateplan/           --profile membership
+aws s3 cp  Subscription.csv         s3://ophan-raw-zuora-increment-subscription/       --profile membership
+aws s3 cp  Contact.csv              s3://ophan-raw-zuora-increment-contact/            --profile membership
+aws s3 cp  PaymentMethod.csv        s3://ophan-raw-zuora-increment-paymentmethod/      --profile membership
+aws s3 cp  Amendment.csv            s3://ophan-raw-zuora-increment-amendment/          --profile membership
+aws s3 cp  Invoice.csv              s3://ophan-raw-zuora-increment-invoice/            --profile membership
+aws s3 cp  Payment.csv              s3://ophan-raw-zuora-increment-payment/            --profile membership
+aws s3 cp  InvoicePayment.csv       s3://ophan-raw-zuora-increment-invoicepayment/     --profile membership
+aws s3 cp  Refund.csv               s3://ophan-raw-zuora-increment-refund/             --profile membership
+aws s3 cp  InvoiceItem.csv          s3://ophan-raw-zuora-increment-invoiceitem/        --profile membership
 ```
 
 ## Auto-discovery of field names


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

On Monday 6th October, pemissions to set ACL lists will be removed from all `ophan-raw` buckets and the Object Ownership for these buckets will be set to `Bucket Owner Enforced`.
This is to satisfy FSBP Requirement [S3.6: S3 general purpose bucket policies should restrict access to other AWS accounts](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-6).

In order to remain consistent with this, this PR changes the instructions in the Readme for direct upload to not inlcude any ACL settings.

I couldn't see any other uploads to S3 in this repo, but please do let me know if I missed any.
